### PR TITLE
Feat(API): Setup Respon API Standar dan Slow Query Logger

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Exceptions;
+
+use App\Traits\ApiResponseTrait;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\Response;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Throwable;
+
+class Handler extends ExceptionHandler
+{
+    use ApiResponseTrait;
+
+    /**
+     * A list of the exception types that are not reported.
+     *
+     * @var array
+     */
+    protected $dontReport = [
+        //
+    ];
+
+    /**
+     * A list of the inputs that are never flashed for validation exceptions.
+     *
+     * @var array
+     */
+    protected $dontFlash = [
+        'current_password',
+        'password',
+        'password_confirmation',
+    ];
+
+    /**
+     * Register the exception handling callbacks for the application.
+     */
+    public function register(): void
+    {
+        // Add custom API exception rendering
+        $this->renderable(function (Throwable $e, $request) {
+            
+            // Only format responses for API requests
+            if ($request->is('api/*')) {
+
+                // 404 - Model or Route not found
+                if ($e instanceof NotFoundHttpException) {
+                    return $this->sendNotFound('Sumber daya atau route tidak ditemukan');
+                }
+
+                // 422 - Validation Failed (from FormRequest)
+                if ($e instanceof ValidationException) {
+                    return $this->sendError(
+                        'Validasi gagal', 
+                        $e->errors(), 
+                        Response::HTTP_UNPROCESSABLE_ENTITY
+                    );
+                }
+
+                // 401 - Unauthenticated
+                if ($e instanceof AuthenticationException) {
+                    return $this->sendError(
+                        'Tidak terautentikasi', 
+                        [], 
+                        Response::HTTP_UNAUTHORIZED
+                    );
+                }
+
+                // 500 - Other Server Errors
+                $errorMessage = app()->isProduction() ? 'Terjadi kesalahan pada server' : $e->getMessage();
+                
+                // Prepare context for logging
+                $context = [
+                    'context' => 'GlobalExceptionHandler', // Mark as globally caught
+                    'url' => $request->fullUrl(),
+                    'method' => $request->method(),
+                    'ip' => $request->ip(),
+                ];
+
+                return $this->sendInternalError($e, $errorMessage, 500, $context);
+            }
+        });
+    }
+}

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -41,7 +41,7 @@ class Handler extends ExceptionHandler
     {
         // Add custom API exception rendering
         $this->renderable(function (Throwable $e, $request) {
-            
+
             // Only format responses for API requests
             if ($request->is('api/*')) {
 
@@ -53,8 +53,8 @@ class Handler extends ExceptionHandler
                 // 422 - Validation Failed (from FormRequest)
                 if ($e instanceof ValidationException) {
                     return $this->sendError(
-                        'Validasi gagal', 
-                        $e->errors(), 
+                        'Validasi gagal',
+                        $e->errors(),
                         Response::HTTP_UNPROCESSABLE_ENTITY
                     );
                 }
@@ -62,15 +62,15 @@ class Handler extends ExceptionHandler
                 // 401 - Unauthenticated
                 if ($e instanceof AuthenticationException) {
                     return $this->sendError(
-                        'Tidak terautentikasi', 
-                        [], 
+                        'Tidak terautentikasi',
+                        [],
                         Response::HTTP_UNAUTHORIZED
                     );
                 }
 
                 // 500 - Other Server Errors
                 $errorMessage = app()->isProduction() ? 'Terjadi kesalahan pada server' : $e->getMessage();
-                
+
                 // Prepare context for logging
                 $context = [
                     'context' => 'GlobalExceptionHandler', // Mark as globally caught

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -23,5 +25,26 @@ class AppServiceProvider extends ServiceProvider
         ResetPassword::createUrlUsing(function (object $notifiable, string $token) {
             return config('app.frontend_url')."/password-reset/$token?email={$notifiable->getEmailForPasswordReset()}";
         });
+
+        // Log slow queries (only in non-production environments)
+        if (! app()->isProduction()) {
+
+            DB::listen(function ($query) {
+
+                // Set the time threshold (in milliseconds)
+                $slowQueryThreshold = 3000; // 3 seconds
+
+                if ($query->time > $slowQueryThreshold) {
+
+                    Log::warning(
+                        'Slow Query Detected: '.$query->sql, // The slow SQL query
+                        [
+                            'time_ms' => $query->time, // Execution time in ms
+                            'bindings' => $query->bindings, // Query parameters
+                        ]
+                    );
+                }
+            });
+        }
     }
 }

--- a/app/Traits/ApiResponseTrait.php
+++ b/app/Traits/ApiResponseTrait.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace App\Traits;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
+
+trait ApiResponseTrait
+{
+    /**
+     * Send a success response without data.
+     *
+     * @param string $message
+     * @param int $code
+     * @return \Illuminate\Http\JsonResponse
+     */
+    protected function sendSuccess(string $message = 'Sukses', int $code = Response::HTTP_OK): JsonResponse
+    {
+        return response()->json([
+            'status' => 'success',
+            'message' => $message,
+        ], $code);
+    }
+
+    /**
+     * Send a success response with data.
+     *
+     * @param mixed $data
+     * @param string $message
+     * @param int $code
+     * @return \Illuminate\Http\JsonResponse
+     */
+    protected function sendSuccessWithData($data, string $message = 'Sukses', int $code = Response::HTTP_OK): JsonResponse
+    {
+        return response()->json([
+            'status' => 'success',
+            'message' => $message,
+            'data' => $data,
+        ], $code);
+    }
+
+    /**
+     * Send a formatted error response.
+     *
+     * @param string $message
+     * @param array $errors
+     * @param int $code
+     * @return \Illuminate\Http\JsonResponse
+     */
+    protected function sendError(string $message = 'Terjadi kesalahan', array $errors = [], int $code = Response::HTTP_BAD_REQUEST): JsonResponse
+    {
+        $response = [
+            'status' => 'error',
+            'message' => $message,
+        ];
+
+        if (!empty($errors)) {
+            $response['errors'] = $errors;
+        }
+
+        return response()->json($response, $code);
+    }
+
+    /**
+     * Send a 404 not found response.
+     *
+     * @param string $message
+     * @return \Illuminate\Http\JsonResponse
+     */
+    protected function sendNotFound(string $message = 'Data tidak ditemukan'): JsonResponse
+    {
+        return $this->sendError($message, [], Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * Send a 500 internal server error response and log the exception.
+     *
+     * @param \Exception $exception
+     * @param string $message
+     * @param int $code
+     * @param array $context
+     * @return \Illuminate\Http\JsonResponse
+     */
+    protected function sendInternalError(
+        \Exception $exception, 
+        string $message = 'Terjadi kesalahan pada server', 
+        int $code = Response::HTTP_INTERNAL_SERVER_ERROR,
+        array $context = [] // Custom context
+    ): JsonResponse
+    {
+        // Prepare basic log data from the exception
+        $logData = [
+            'file' => $exception->getFile(), // File where the error occurred
+            'line' => $exception->getLine(), // Line where the error occurred
+        ];
+
+        // Merge $logData with your custom $context
+        $fullContext = array_merge($logData, $context);
+
+        // Log the error with the main exception message and full context
+        Log::error($exception->getMessage(), $fullContext);
+        
+        return $this->sendError($message, [], $code);
+    }
+}

--- a/app/Traits/ApiResponseTrait.php
+++ b/app/Traits/ApiResponseTrait.php
@@ -10,10 +10,6 @@ trait ApiResponseTrait
 {
     /**
      * Send a success response without data.
-     *
-     * @param string $message
-     * @param int $code
-     * @return \Illuminate\Http\JsonResponse
      */
     protected function sendSuccess(string $message = 'Sukses', int $code = Response::HTTP_OK): JsonResponse
     {
@@ -26,10 +22,7 @@ trait ApiResponseTrait
     /**
      * Send a success response with data.
      *
-     * @param mixed $data
-     * @param string $message
-     * @param int $code
-     * @return \Illuminate\Http\JsonResponse
+     * @param  mixed  $data
      */
     protected function sendSuccessWithData($data, string $message = 'Sukses', int $code = Response::HTTP_OK): JsonResponse
     {
@@ -42,11 +35,6 @@ trait ApiResponseTrait
 
     /**
      * Send a formatted error response.
-     *
-     * @param string $message
-     * @param array $errors
-     * @param int $code
-     * @return \Illuminate\Http\JsonResponse
      */
     protected function sendError(string $message = 'Terjadi kesalahan', array $errors = [], int $code = Response::HTTP_BAD_REQUEST): JsonResponse
     {
@@ -55,7 +43,7 @@ trait ApiResponseTrait
             'message' => $message,
         ];
 
-        if (!empty($errors)) {
+        if (! empty($errors)) {
             $response['errors'] = $errors;
         }
 
@@ -64,9 +52,6 @@ trait ApiResponseTrait
 
     /**
      * Send a 404 not found response.
-     *
-     * @param string $message
-     * @return \Illuminate\Http\JsonResponse
      */
     protected function sendNotFound(string $message = 'Data tidak ditemukan'): JsonResponse
     {
@@ -75,20 +60,13 @@ trait ApiResponseTrait
 
     /**
      * Send a 500 internal server error response and log the exception.
-     *
-     * @param \Exception $exception
-     * @param string $message
-     * @param int $code
-     * @param array $context
-     * @return \Illuminate\Http\JsonResponse
      */
     protected function sendInternalError(
-        \Exception $exception, 
-        string $message = 'Terjadi kesalahan pada server', 
+        \Exception $exception,
+        string $message = 'Terjadi kesalahan pada server',
         int $code = Response::HTTP_INTERNAL_SERVER_ERROR,
         array $context = [] // Custom context
-    ): JsonResponse
-    {
+    ): JsonResponse {
         // Prepare basic log data from the exception
         $logData = [
             'file' => $exception->getFile(), // File where the error occurred
@@ -100,7 +78,7 @@ trait ApiResponseTrait
 
         // Log the error with the main exception message and full context
         Log::error($exception->getMessage(), $fullContext);
-        
+
         return $this->sendError($message, [], $code);
     }
 }


### PR DESCRIPTION
## 🎟️ Tautkan Isu/Tiket

Closes #10 

## ✏️ Deskripsi Perubahan

PR ini berfokus pada **setup arsitektur** untuk standarisasi respon API dan *logging* performa. Perubahan ini mengimplementasikan fondasi yang akan digunakan oleh semua *controller*.

Perubahan utama meliputi:
1.  **Menambahkan `app/Traits/ApiResponseTrait.php`**: Berisi *helper method* (`sendSuccess`, `sendError`, `sendInternalError`, dll) dengan pesan default Bahasa Indonesia dan *logging* yang efisien (tanpa *full trace*).
2.  **Memodifikasi `app/Exceptions/Handler.php`**: Mencegat *exception* API global (404, 422, 401, 500) dan memformat ulangnya secara otomatis menggunakan `ApiResponseTrait`.
3.  **Memperbarui `AppServiceProvider.php`**: Mendaftarkan `DB::listen()` yang akan mencatat *query* lambat (di atas 2 detik) ke `Log::warning`.

**Penting:** PR ini **tidak** menyertakan implementasi *trait* di *controller* spesifik (misal: `VenueController`). Hal itu akan dilakukan di PR/tugas terpisah setelah fondasi ini di-*merge*.

## 🧪 Cara Pengujian

Fokus pengujian adalah pada *error* otomatis yang ditangani oleh `Handler.php` dan `AppServiceProvider.php`.

1.  **Test 422 (Validasi Gagal):**
    * Panggil *endpoint* `POST` yang memiliki validasi (misal: `/api/v1/register` atau `/api/v1/login`) dengan data kosong/tidak valid.
    * **Harapan:** Respon harus 422 dengan format JSON: `{"status": "error", "message": "Validasi gagal", "errors": {...}}`.

2.  **Test 404 (Route Tidak Ditemukan):**
    * Panggil `GET /api/v1/url-yang-pasti-tidak-ada`.
    * **Harapan:** Respon harus 404 dengan format JSON: `{"status": "error", "message": "Sumber daya atau route tidak ditemukan"}`.

3.  **Test 401 (Tidak Terotentikasi):**
    * Panggil *endpoint* yang terproteksi (misal: `/api/v1/logout` atau *endpoint* booking) tanpa mengirim *Bearer Token*.
    * **Harapan:** Respon harus 401 dengan format JSON: `{"status": "error", "message": "Tidak terautentikasi"}`.

4.  **Test Slow Query (Warning Log):**
    * Buat *route* *dummy* (bisa di `routes/web.php` untuk tes sementara) yang menjalankan `DB::select('SELECT SLEEP(3)');`.
    * Panggil *route* *dummy* tersebut.
    * **Harapan:** Periksa file `storage/logs/laravel.log`. Harus ada log `WARNING` baru dengan pesan `Slow Query Detected: SELECT SLEEP(3)`.

## ✅ Checklist

-   [x] Kode saya mengikuti standar *coding* proyek ini.
-   [ ] Saya telah memperbarui dokumentasi (jika diperlukan).
-   [ ] Saya telah menambahkan *test case* (jika diperlukan).
-   [x] Semua tes *existing* (jika ada) lolos.