### PR TITLE
feat(auth): Add RoleMiddleware for admin authorization

### DIFF
--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Traits\ApiResponseTrait;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class RoleMiddleware
+{
+    use ApiResponseTrait;
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next, ...$roles): Response
+    {
+        $user = Auth::guard('api_user')->user();
+
+        if (! $user || ! in_array($user->role, $roles)) {
+            return $this->sendError(
+                'Anda tidak memiliki izin untuk mengakses ini',
+                [],
+                Response::HTTP_FORBIDDEN
+            );
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -20,6 +20,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->alias([
             'verified' => \App\Http\Middleware\EnsureEmailIsVerified::class,
+            'role' => \App\Http\Middleware\RoleMiddleware::class,
         ]);
 
         //


### PR DESCRIPTION
## 🎟️ Tautkan Isu/Tiket

Closes #14 

## ✏️ Deskripsi Perubahan

PR ini mengimplementasikan fondasi untuk otorisasi berbasis peran (RBAC), sesuai dengan isu yang ditautkan. Fitur ini krusial untuk melindungi *endpoint* khusus Admin (Modul 5).

Perubahan utama:

1.  Membuat `app/Http/Middleware/RoleMiddleware.php`.
2.  *Middleware* ini mengecek kolom `role` dari *user* yang sedang login (khususnya *guard* `api_user`) terhadap daftar peran yang diizinkan (misal: 'admin').
3.  Jika otorisasi gagal, *middleware* akan mengembalikan respon JSON 403 (Forbidden) kustom menggunakan `ApiResponseTrait`.
4.  Mendaftarkan *middleware* ini sebagai *alias* `'role'` di `bootstrap/app.php`.

## 🧪 Cara Pengujian

Karena *branch* ini hanya membuat *middleware*-nya, pengujian fungsional penuh baru bisa dilakukan saat *endpoint* Admin dibuat. Namun, pengujian berikut dapat memverifikasi bahwa *middleware* telah terdaftar:

1.  Jalankan `php artisan optimize:clear` (untuk mendaftarkan *alias* baru).
2.  (Opsional) Untuk tes manual:
      * Buka `routes/api.php`.
      * Tambahkan *route* tes sementara di dalam grup `auth:api_user`:
        ```php
        Route::get('/admin-test', function() {
            return response()->json(['message' => 'Anda Admin!']);
        })->middleware('role:admin');
        ```
      * Panggil `GET /api/v1/admin-test` di Postman menggunakan **Token User Biasa**.
      * **Harapan:** Respon 403: `{"status": "error", "message": "Anda tidak memiliki izin..."}`.
      * (Jika Anda punya user admin di DB) Panggil *route* yang sama menggunakan **Token Admin**.
      * **Harapan:** Respon 200: `{"message": "Anda Admin!"}`.
      * Hapus *route* tes sementara tersebut.

## ✅ Checklist

  - [x] Kode saya mengikuti standar *coding* proyek ini.
  - [ ] Saya telah memperbarui dokumentasi (jika diperlukan).
  - [ ] Saya telah menambahkan *test case* (jika diperlukan).
  - [x] Semua tes *existing* (jika ada) lolos.